### PR TITLE
cijoe/workflows: add INSTALL_FLAMEGRAPH=true when building qcow image

### DIFF
--- a/cijoe/workflows/build_qcow2_using_qemu.yaml
+++ b/cijoe/workflows/build_qcow2_using_qemu.yaml
@@ -51,7 +51,7 @@ steps:
 - name: pkgdep_and_autotest_setup
   run: |
     /tmp/spdk/scripts/pkgdep.sh -a
-    /tmp/spdk/test/common/config/autotest_setup.sh --install-deps --upgrade --test-conf="lcov"
+    INSTALL_FLAMEGRAPH=true /tmp/spdk/test/common/config/autotest_setup.sh --install-deps --upgrade --test-conf="lcov"
     
 - name: guest_shutdown
   run: |


### PR DESCRIPTION
We need this installed for final step in the autorun.sh script.