### PR TITLE
fix(build_container): update context path from 'spdk' to '.'

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -25,7 +25,7 @@ jobs:
         docker build \
         -t $IMAGE_ID \
         -f ci/dockerfiles/fedora/Dockerfile \
-        spdk
+        .
 
     - name: Log into GitHub Container Registry
       run: |


### PR DESCRIPTION
Replaced the 'spdk' context path with '.' as the container now only serves to:

* Start qemu-guests
* Provide a Python environment with necessary dependencies

The 'spdk' path is no longer required since SPDK and autorun test scripts are no longer included.